### PR TITLE
Add zoom and navigation controls with collapsible footer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,7 @@
 
 :root {
   --font-mono: 'JetBrains Mono', monospace;
+  --card-size: 240px;
 }
 
 @layer base {

--- a/app/men/page.tsx
+++ b/app/men/page.tsx
@@ -1,0 +1,13 @@
+import UIControls from '@/components/UIControls';
+
+export default function MenPage() {
+  return (
+    <main className="min-h-screen pt-14 pb-24">
+      <UIControls gridId="product-grid" />
+      <section className="p-4">
+        <p>Men page placeholder.</p>
+      </section>
+    </main>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,20 +2,22 @@
 
 import { motion } from 'framer-motion';
 import { ProductGrid } from '@/components/ProductGrid';
+import UIControls from '@/components/UIControls';
 import { products } from '@/data/products';
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-white pt-20 pb-8">
+    <main className="min-h-screen bg-white pt-14 pb-24">
+      <UIControls gridId="product-grid" />
       <div className="max-w-7xl mx-auto px-6">
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 0.5 }}
         >
-          <ProductGrid products={products} />
+          <ProductGrid products={products} gridId="product-grid" />
         </motion.div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/app/women/page.tsx
+++ b/app/women/page.tsx
@@ -1,0 +1,13 @@
+import UIControls from '@/components/UIControls';
+
+export default function WomenPage() {
+  return (
+    <main className="min-h-screen pt-14 pb-24">
+      <UIControls gridId="product-grid" />
+      <section className="p-4">
+        <p>Women page placeholder.</p>
+      </section>
+    </main>
+  );
+}
+

--- a/components/ProductGrid.tsx
+++ b/components/ProductGrid.tsx
@@ -5,14 +5,22 @@ import { Product } from '@/data/products';
 
 interface ProductGridProps {
   products: Product[];
+  gridId?: string;
 }
 
-export function ProductGrid({ products }: ProductGridProps) {
+export function ProductGrid({ products, gridId = "product-grid" }: ProductGridProps) {
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-9 gap-4 md:gap-6">
+    <div
+      id={gridId}
+      className="grid gap-4 md:gap-6"
+      style={{
+        gridTemplateColumns: "repeat(auto-fill, minmax(var(--card-size, 240px), 1fr))",
+      }}
+    >
       {products.map((product, index) => (
         <ProductCard key={product.id} product={product} index={index} />
       ))}
     </div>
   );
 }
+

--- a/components/UIControls.tsx
+++ b/components/UIControls.tsx
@@ -1,0 +1,88 @@
+"use client";
+import React from "react";
+import { Plus, Minus, X, Home, UserRound, Venus, ChevronDown } from "lucide-react";
+
+type Props = {
+  /** id du conteneur grille qui liste les cartes produits */
+  gridId?: string; // défaut: "product-grid"
+};
+
+export default function UIControls({ gridId = "product-grid" }: Props) {
+  const [isZoomed, setIsZoomed] = React.useState(false);
+  const [footerOpen, setFooterOpen] = React.useState(false);
+
+  // Applique la taille des cartes via une CSS var sur la grille
+  React.useEffect(() => {
+    const grid = document.getElementById(gridId);
+    if (!grid) return;
+    grid.style.setProperty("--card-size", isZoomed ? "300px" : "240px"); // ajuste si besoin
+  }, [isZoomed, gridId]);
+
+  return (
+    <>
+      {/* TOP BAR */}
+      <div className="fixed top-0 left-0 right-0 z-40 bg-white/90 dark:bg-black/80 backdrop-blur border-b">
+        <div className="mx-auto max-w-6xl px-4 h-14 flex items-center justify-between">
+          {/* + / − = zoom/dezoom */}
+          <button
+            aria-label={isZoomed ? "Dézoomer" : "Zoomer"}
+            onClick={() => setIsZoomed((v) => !v)}
+            className="p-2 rounded hover:scale-105 active:scale-95 transition"
+            title={isZoomed ? "Dézoomer les cartes" : "Zoomer les cartes"}
+          >
+            {isZoomed ? <Minus /> : <Plus />}
+          </button>
+
+          {/* Icônes Home + Homme + Femme */}
+          <nav className="flex items-center gap-5">
+            <a href="/" aria-label="Home" className="p-1"><Home /></a>
+            <a href="/men" aria-label="Vêtements homme" className="p-1"><UserRound /></a>
+            <a href="/women" aria-label="Vêtements femme" className="p-1"><Venus /></a>
+          </nav>
+
+          {/* Réservé à d'autres actions éventuelles */}
+          <div className="w-8" />
+        </div>
+      </div>
+
+      {/* FOOTER pliable via la croix, fermé par défaut à chaque reload */}
+      <div className="fixed left-0 right-0 bottom-0 z-40">
+        <div className="mx-auto max-w-6xl px-4">
+          <div className="rounded-t-xl border bg-white/90 dark:bg-black/80 backdrop-blur">
+            <div className="flex items-center justify-between px-2">
+              <button
+                onClick={() => setFooterOpen((v) => !v)}
+                aria-expanded={footerOpen}
+                aria-controls="footer-links"
+                className="m-2 h-9 w-9 grid place-items-center rounded hover:scale-105 active:scale-95 transition"
+                title="Ouvrir le menu pied de page"
+              >
+                <X />
+              </button>
+              <ChevronDown
+                className={`mr-3 transition-transform ${footerOpen ? "rotate-180" : ""}`}
+                aria-hidden="true"
+              />
+            </div>
+
+            <div
+              id="footer-links"
+              className={`overflow-hidden transition-[max-height,opacity] duration-300 ${
+                footerOpen ? "max-h-40 opacity-100" : "max-h-0 opacity-0"
+              }`}
+            >
+              <div className="px-4 pb-4 flex items-center gap-6 text-sm">
+                <a href="/contact">Contact</a>
+                <a href="/terms">Terms</a>
+                <a href="/privacy">Privacy</a>
+                <a href="/accessibility">Accessibility</a>
+                <a href="/cookies">Cookies</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `UIControls` component with product zoom, page shortcuts, and a foldable footer
- default `--card-size` CSS variable and use it in `ProductGrid`
- mount controls on home page and add placeholder Men and Women routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b40b67fc388331a5b086ae5d7b93ae