### PR TITLE
Add zoom control and collapsible footer

### DIFF
--- a/app/men/page.tsx
+++ b/app/men/page.tsx
@@ -1,11 +1,13 @@
 import UIControls from '@/components/UIControls';
+import { ProductGrid } from '@/components/ProductGrid';
+import { products } from '@/data/products';
 
 export default function MenPage() {
   return (
-    <main className="min-h-screen pt-14 pb-24">
+    <main className="min-h-screen pt-14 pb-20">
       <UIControls gridId="product-grid" />
-      <section className="p-4">
-        <p>Men page placeholder.</p>
+      <section className="mx-auto max-w-7xl px-4">
+        <ProductGrid products={products} gridId="product-grid" />
       </section>
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { products } from '@/data/products';
 
 export default function Home() {
   return (
-    <main className="min-h-screen bg-white pt-14 pb-24">
+    <main className="min-h-screen bg-white pt-14 pb-20">
       <UIControls gridId="product-grid" />
       <div className="max-w-7xl mx-auto px-6">
         <motion.div

--- a/app/women/page.tsx
+++ b/app/women/page.tsx
@@ -1,11 +1,13 @@
 import UIControls from '@/components/UIControls';
+import { ProductGrid } from '@/components/ProductGrid';
+import { products } from '@/data/products';
 
 export default function WomenPage() {
   return (
-    <main className="min-h-screen pt-14 pb-24">
+    <main className="min-h-screen pt-14 pb-20">
       <UIControls gridId="product-grid" />
-      <section className="p-4">
-        <p>Women page placeholder.</p>
+      <section className="mx-auto max-w-7xl px-4">
+        <ProductGrid products={products} gridId="product-grid" />
       </section>
     </main>
   );

--- a/components/UIControls.tsx
+++ b/components/UIControls.tsx
@@ -1,82 +1,99 @@
 "use client";
 import React from "react";
-import { Plus, Minus, X, Home, UserRound, Venus, ChevronDown } from "lucide-react";
+import { Plus, Minus, X, Home, UserRound, Venus } from "lucide-react";
 
 type Props = {
-  /** id du conteneur grille qui liste les cartes produits */
+  /** id du conteneur grid produits */
   gridId?: string; // défaut: "product-grid"
 };
 
 export default function UIControls({ gridId = "product-grid" }: Props) {
-  const [isZoomed, setIsZoomed] = React.useState(false);
+  // sm -> md -> lg -> sm
+  const [size, setSize] = React.useState<"sm" | "md" | "lg">("md");
   const [footerOpen, setFooterOpen] = React.useState(false);
 
-  // Applique la taille des cartes via une CSS var sur la grille
+  const step = () =>
+    setSize((s) => (s === "sm" ? "md" : s === "md" ? "lg" : "sm"));
+
+  // applique --card-size sur la grille
   React.useEffect(() => {
-    const grid = document.getElementById(gridId);
+    const grid =
+      document.getElementById(gridId) ||
+      (document.querySelector("[data-product-grid]") as HTMLElement | null);
     if (!grid) return;
-    grid.style.setProperty("--card-size", isZoomed ? "300px" : "240px"); // ajuste si besoin
-  }, [isZoomed, gridId]);
+    const px = size === "sm" ? "180px" : size === "md" ? "240px" : "320px";
+    grid.style.setProperty("--card-size", px);
+  }, [size, gridId]);
+
+  const isZoomed = size !== "md"; // pour décider +/−
 
   return (
     <>
-      {/* TOP BAR */}
+      {/* TOP BAR FIXE */}
       <div className="fixed top-0 left-0 right-0 z-40 bg-white/90 dark:bg-black/80 backdrop-blur border-b">
-        <div className="mx-auto max-w-6xl px-4 h-14 flex items-center justify-between">
-          {/* + / − = zoom/dezoom */}
+        <div className="mx-auto max-w-7xl px-4 h-14 flex items-center justify-between">
+          {/* + / − */}
           <button
-            aria-label={isZoomed ? "Dézoomer" : "Zoomer"}
-            onClick={() => setIsZoomed((v) => !v)}
+            type="button"
+            aria-label={isZoomed ? "Réinitialiser taille" : "Changer taille"}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              step();
+            }}
             className="p-2 rounded hover:scale-105 active:scale-95 transition"
-            title={isZoomed ? "Dézoomer les cartes" : "Zoomer les cartes"}
+            title={isZoomed ? "−" : "+"}
           >
             {isZoomed ? <Minus /> : <Plus />}
           </button>
 
-          {/* Icônes Home + Homme + Femme */}
-          <nav className="flex items-center gap-5">
+          {/* Home + Homme + Femme */}
+          <nav className="flex items-center gap-6">
             <a href="/" aria-label="Home" className="p-1"><Home /></a>
             <a href="/men" aria-label="Vêtements homme" className="p-1"><UserRound /></a>
             <a href="/women" aria-label="Vêtements femme" className="p-1"><Venus /></a>
           </nav>
 
-          {/* Réservé à d'autres actions éventuelles */}
           <div className="w-8" />
         </div>
       </div>
 
-      {/* FOOTER pliable via la croix, fermé par défaut à chaque reload */}
-      <div className="fixed left-0 right-0 bottom-0 z-40">
-        <div className="mx-auto max-w-6xl px-4">
-          <div className="rounded-t-xl border bg-white/90 dark:bg-black/80 backdrop-blur">
-            <div className="flex items-center justify-between px-2">
-              <button
-                onClick={() => setFooterOpen((v) => !v)}
-                aria-expanded={footerOpen}
-                aria-controls="footer-links"
-                className="m-2 h-9 w-9 grid place-items-center rounded hover:scale-105 active:scale-95 transition"
-                title="Ouvrir le menu pied de page"
-              >
-                <X />
-              </button>
-              <ChevronDown
-                className={`mr-3 transition-transform ${footerOpen ? "rotate-180" : ""}`}
-                aria-hidden="true"
-              />
-            </div>
+      {/* FOOTER FIXE EN BAS GAUCHE */}
+      <div className="fixed left-0 right-0 bottom-0 z-40 pointer-events-none">
+        <div className="mx-auto max-w-7xl px-4">
+          <div className="relative">
+            <div className="rounded-t-xl border bg-white/90 dark:bg-black/80 backdrop-blur pointer-events-auto">
+              <div className="h-12 flex items-center">
+                {/* CROIX */}
+                <button
+                  type="button"
+                  onClick={() => setFooterOpen((v) => !v)}
+                  aria-expanded={footerOpen}
+                  aria-controls="footer-links"
+                  className="ml-2 h-9 w-9 grid place-items-center rounded hover:scale-105 active:scale-95 transition"
+                  title={footerOpen ? "Fermer" : "Ouvrir"}
+                >
+                  <X />
+                </button>
 
-            <div
-              id="footer-links"
-              className={`overflow-hidden transition-[max-height,opacity] duration-300 ${
-                footerOpen ? "max-h-40 opacity-100" : "max-h-0 opacity-0"
-              }`}
-            >
-              <div className="px-4 pb-4 flex items-center gap-6 text-sm">
-                <a href="/contact">Contact</a>
-                <a href="/terms">Terms</a>
-                <a href="/privacy">Privacy</a>
-                <a href="/accessibility">Accessibility</a>
-                <a href="/cookies">Cookies</a>
+                {/* LIENS déployés GAUCHE -> DROITE */}
+                <div className="relative flex-1">
+                  <div
+                    id="footer-links"
+                    className={
+                      "absolute left-12 top-1/2 -translate-y-1/2 flex items-center gap-6 text-sm overflow-hidden transition-all duration-300"}
+                    style={{
+                      maxWidth: footerOpen ? "640px" : "0px",
+                      opacity: footerOpen ? 1 : 0,
+                    }}
+                  >
+                    <a href="/contact">Contact</a>
+                    <a href="/terms">Terms</a>
+                    <a href="/privacy">Privacy</a>
+                    <a href="/accessibility">Accessibility</a>
+                    <a href="/cookies">Cookies</a>
+                  </div>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Implement 3-level zoom control for product grid driven by CSS variable
- Add fixed top bar with Home/Homme/Femme icons and bottom-left expandable footer
- Wire UIControls and grid to home, men, and women listing pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b41125881c8331ac2b062523579393