### PR TITLE
Centralize UIControls in root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Inter, JetBrains_Mono } from 'next/font/google';
 import { CartProvider } from '@/context/CartContext';
 import { Navbar } from '@/components/Navbar';
 import { Footer } from '@/components/Footer';
+import UIControls from '@/components/UIControls';
 
 const inter = Inter({ subsets: ['latin'] });
 const jetbrainsMono = JetBrains_Mono({ 
@@ -24,6 +25,7 @@ export default function RootLayout({
         <meta name="description" content="Premium secondhand clothing store" />
       </head>
       <body className={`${inter.className} ${jetbrainsMono.variable} font-mono bg-white text-black`}>
+        <UIControls gridId="product-grid" />
         <CartProvider>
           <Navbar />
           <main className="min-h-screen">

--- a/app/men/page.tsx
+++ b/app/men/page.tsx
@@ -1,11 +1,9 @@
-import UIControls from '@/components/UIControls';
 import { ProductGrid } from '@/components/ProductGrid';
 import { products } from '@/data/products';
 
 export default function MenPage() {
   return (
     <main className="min-h-screen pt-14 pb-20">
-      <UIControls gridId="product-grid" />
       <section className="mx-auto max-w-7xl px-4">
         <ProductGrid products={products} gridId="product-grid" />
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,13 +2,11 @@
 
 import { motion } from 'framer-motion';
 import { ProductGrid } from '@/components/ProductGrid';
-import UIControls from '@/components/UIControls';
 import { products } from '@/data/products';
 
 export default function Home() {
   return (
     <main className="min-h-screen bg-white pt-14 pb-20">
-      <UIControls gridId="product-grid" />
       <div className="max-w-7xl mx-auto px-6">
         <motion.div
           initial={{ opacity: 0 }}

--- a/app/women/page.tsx
+++ b/app/women/page.tsx
@@ -1,11 +1,9 @@
-import UIControls from '@/components/UIControls';
 import { ProductGrid } from '@/components/ProductGrid';
 import { products } from '@/data/products';
 
 export default function WomenPage() {
   return (
     <main className="min-h-screen pt-14 pb-20">
-      <UIControls gridId="product-grid" />
       <section className="mx-auto max-w-7xl px-4">
         <ProductGrid products={products} gridId="product-grid" />
       </section>

--- a/components/UIControls.tsx
+++ b/components/UIControls.tsx
@@ -2,37 +2,52 @@
 import React from "react";
 import { Plus, Minus, X, Home, UserRound, Venus } from "lucide-react";
 
-type Props = {
-  /** id du conteneur grid produits */
-  gridId?: string; // défaut: "product-grid"
-};
+type Props = { gridId?: string };
+const MOUNT_ATTR = "data-ui-controls-mounted";
 
 export default function UIControls({ gridId = "product-grid" }: Props) {
-  // sm -> md -> lg -> sm
+  const [canRender, setCanRender] = React.useState(false);
   const [size, setSize] = React.useState<"sm" | "md" | "lg">("md");
   const [footerOpen, setFooterOpen] = React.useState(false);
 
-  const step = () =>
-    setSize((s) => (s === "sm" ? "md" : s === "md" ? "lg" : "sm"));
+  React.useLayoutEffect(() => {
+    const existing = document.body.querySelector(`[${MOUNT_ATTR}="true"]`);
+    if (existing) {
+      setCanRender(false);
+      return;
+    }
+    document.body.setAttribute(MOUNT_ATTR, "true");
+    setCanRender(true);
+    return () => {
+      // libère l’attribut si ce composant est démonté
+      if (document.body.getAttribute(MOUNT_ATTR) === "true") {
+        document.body.removeAttribute(MOUNT_ATTR);
+      }
+    };
+  }, []);
 
-  // applique --card-size sur la grille
   React.useEffect(() => {
+    if (!canRender) return;
     const grid =
-      document.getElementById(gridId) ||
+      (document.getElementById(gridId) as HTMLElement | null) ??
       (document.querySelector("[data-product-grid]") as HTMLElement | null);
     if (!grid) return;
-    const px = size === "sm" ? "180px" : size === "md" ? "240px" : "320px";
-    grid.style.setProperty("--card-size", px);
-  }, [size, gridId]);
+    grid.style.setProperty(
+      "--card-size",
+      size === "sm" ? "180px" : size === "md" ? "240px" : "320px"
+    );
+  }, [size, gridId, canRender]);
 
-  const isZoomed = size !== "md"; // pour décider +/−
+  if (!canRender) return null;
+
+  const step = () =>
+    setSize((s) => (s === "sm" ? "md" : s === "md" ? "lg" : "sm"));
+  const isZoomed = size !== "md";
 
   return (
     <>
-      {/* TOP BAR FIXE */}
       <div className="fixed top-0 left-0 right-0 z-40 bg-white/90 dark:bg-black/80 backdrop-blur border-b">
         <div className="mx-auto max-w-7xl px-4 h-14 flex items-center justify-between">
-          {/* + / − */}
           <button
             type="button"
             aria-label={isZoomed ? "Réinitialiser taille" : "Changer taille"}
@@ -46,53 +61,49 @@ export default function UIControls({ gridId = "product-grid" }: Props) {
           >
             {isZoomed ? <Minus /> : <Plus />}
           </button>
-
-          {/* Home + Homme + Femme */}
           <nav className="flex items-center gap-6">
-            <a href="/" aria-label="Home" className="p-1"><Home /></a>
-            <a href="/men" aria-label="Vêtements homme" className="p-1"><UserRound /></a>
-            <a href="/women" aria-label="Vêtements femme" className="p-1"><Venus /></a>
+            <a href="/" aria-label="Home" className="p-1">
+              <Home />
+            </a>
+            <a href="/men" aria-label="Vêtements homme" className="p-1">
+              <UserRound />
+            </a>
+            <a href="/women" aria-label="Vêtements femme" className="p-1">
+              <Venus />
+            </a>
           </nav>
-
           <div className="w-8" />
         </div>
       </div>
 
-      {/* FOOTER FIXE EN BAS GAUCHE */}
       <div className="fixed left-0 right-0 bottom-0 z-40 pointer-events-none">
         <div className="mx-auto max-w-7xl px-4">
-          <div className="relative">
-            <div className="rounded-t-xl border bg-white/90 dark:bg-black/80 backdrop-blur pointer-events-auto">
-              <div className="h-12 flex items-center">
-                {/* CROIX */}
-                <button
-                  type="button"
-                  onClick={() => setFooterOpen((v) => !v)}
-                  aria-expanded={footerOpen}
-                  aria-controls="footer-links"
-                  className="ml-2 h-9 w-9 grid place-items-center rounded hover:scale-105 active:scale-95 transition"
-                  title={footerOpen ? "Fermer" : "Ouvrir"}
+          <div className="relative pointer-events-auto rounded-t-xl border bg-white/90 dark:bg-black/80 backdrop-blur">
+            <div className="h-12 flex items-center">
+              <button
+                type="button"
+                onClick={() => setFooterOpen((v) => !v)}
+                aria-expanded={footerOpen}
+                aria-controls="footer-links"
+                className="ml-2 h-9 w-9 grid place-items-center rounded hover:scale-105 active:scale-95 transition"
+                title={footerOpen ? "Fermer" : "Ouvrir"}
+              >
+                <X />
+              </button>
+              <div className="relative flex-1">
+                <div
+                  id="footer-links"
+                  className="absolute left-12 top-1/2 -translate-y-1/2 flex items-center gap-6 text-sm overflow-hidden transition-all duration-300"
+                  style={{
+                    maxWidth: footerOpen ? "640px" : "0px",
+                    opacity: footerOpen ? 1 : 0,
+                  }}
                 >
-                  <X />
-                </button>
-
-                {/* LIENS déployés GAUCHE -> DROITE */}
-                <div className="relative flex-1">
-                  <div
-                    id="footer-links"
-                    className={
-                      "absolute left-12 top-1/2 -translate-y-1/2 flex items-center gap-6 text-sm overflow-hidden transition-all duration-300"}
-                    style={{
-                      maxWidth: footerOpen ? "640px" : "0px",
-                      opacity: footerOpen ? 1 : 0,
-                    }}
-                  >
-                    <a href="/contact">Contact</a>
-                    <a href="/terms">Terms</a>
-                    <a href="/privacy">Privacy</a>
-                    <a href="/accessibility">Accessibility</a>
-                    <a href="/cookies">Cookies</a>
-                  </div>
+                  <a href="/contact">Contact</a>
+                  <a href="/terms">Terms</a>
+                  <a href="/privacy">Privacy</a>
+                  <a href="/accessibility">Accessibility</a>
+                  <a href="/cookies">Cookies</a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- render UIControls once at the root layout
- remove page-level UIControls components
- add single-mount guard to UIControls to prevent duplicates

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b424a011948331a694213da510a93c